### PR TITLE
Add missing installation instruction for jekyll-seo-plugin.

### DIFF
--- a/_posts/2018-01-02-twitter-cards-for-jekyll-with-jekyll-seo-tag.md
+++ b/_posts/2018-01-02-twitter-cards-for-jekyll-with-jekyll-seo-tag.md
@@ -34,6 +34,12 @@ This will make GitHub pages know to use the plugin.
 
 To install locally run `gem install jekyll-seo-tag` at the command line.
 
+Finally, add the following tag inside the `<head>` in your site's template(s):
+
+```
+{% raw %}{% seo %}{% endraw %}
+```
+
 ### Declaring Your Twitter Username In _config.yml
 
 Next, you'll need to declare your Twitter username in your `_config.yml`. Without this, jekyll-seo-tag will not include the meta tags. 


### PR DESCRIPTION
Without the tag, the seo plugin will not do anything.